### PR TITLE
Move submodules to https instead of ssh, fix inclusion of boost.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "libs/mangle"]
 	path = libs/mangle
-	url = git://github.com/korslund/mangle
+	url = https://github.com/korslund/mangle
 [submodule "libs/spread"]
 	path = libs/spread
-	url = git://github.com/korslund/spread
+	url = https://github.com/korslund/spread
 [submodule "libs/unpackcpp"]
 	path = libs/unpackcpp
-	url = git://github.com/korslund/UnpackCpp.git
+	url = https://github.com/korslund/UnpackCpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(ZLIB REQUIRED)
 find_package(wxWidgets COMPONENTS core base adv REQUIRED)
 include(${wxWidgets_USE_FILE})
 
+add_definitions(-DNEED_LOCKGUARD=1)
 include_directories("./")
 include_directories("libs/")
 include_directories("libs/spread/")


### PR DESCRIPTION
Unauthenticated ssh no longer works on github, and the setting of the curious definition is to fix boost library inclusion. Resolves #8.